### PR TITLE
[CI/CD][Task] - Aplicar convencao v2 em templates e parser

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-geral.yml
+++ b/.github/ISSUE_TEMPLATE/1-geral.yml
@@ -1,62 +1,13 @@
-name: "Issue Geral"
-description: "V1.0.0 - [Label][Type] - Objetivo"
+name: "Issue-objetivo (Geral)"
+description: "Objetivo/entrega que sera quebrado em sub-issues"
 projects: ["CLT-Devops/3"]
 type: "Task"
 body:
-  - type: input
-    id: version
-    attributes:
-      label: Versao
-      description: "Use o padrao com 3 blocos (ex.: V1.0.0)."
-      placeholder: "V1.0.0"
-    validations:
-      required: true
-
-  - type: dropdown
-    id: label
-    attributes:
-      label: Label
-      description: Label obrigatoria para classificacao.
-      options:
-        - DB
-        - AI
-        - Code
-        - Server
-        - Domain
-        - Story
-        - API
-        - Webhook
-        - AWS
-        - ETL
-        - Docker
-        - CI/CD
-        - Log
-        - QA
-        - Sec
-        - UI/UX
-        - Layout
-        - Component
-    validations:
-      required: true
-
-  - type: dropdown
-    id: type
-    attributes:
-      label: Type
-      description: Type obrigatorio da issue.
-      options:
-        - Task
-        - Bug
-        - Improvement
-        - Feature
-        - Story
-    validations:
-      required: true
-
   - type: textarea
     id: description_text
     attributes:
       label: Descricao
-      placeholder: "Descreva resumidamente a demanda..."
+      description: "Objetivo da issue. Sem versao, sem label, sem type - isso vive nas sub-issues."
+      placeholder: "Ex.: Agente de analise"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/2-web.yml
+++ b/.github/ISSUE_TEMPLATE/2-web.yml
@@ -1,62 +1,13 @@
-name: "Issue Web"
-description: "V1.0.0.0 - [Label][Type] - Objetivo"
+name: "Issue-objetivo (Web/Analytics)"
+description: "Objetivo/entrega no contexto Web/Analytics - sera quebrado em sub-issues"
 projects: ["CLT-Devops/3"]
 type: "Task"
 body:
-  - type: input
-    id: version
-    attributes:
-      label: Versao
-      description: "Use o padrao Web com 4 blocos (ex.: V1.0.0.0)."
-      placeholder: "V1.0.0.0"
-    validations:
-      required: true
-
-  - type: dropdown
-    id: label
-    attributes:
-      label: Label
-      description: Label obrigatoria para classificacao.
-      options:
-        - DB
-        - AI
-        - Code
-        - Server
-        - Domain
-        - Story
-        - API
-        - Webhook
-        - AWS
-        - ETL
-        - Docker
-        - CI/CD
-        - Log
-        - QA
-        - Sec
-        - UI/UX
-        - Layout
-        - Component
-    validations:
-      required: true
-
-  - type: dropdown
-    id: type
-    attributes:
-      label: Type
-      description: Type obrigatorio da issue.
-      options:
-        - Task
-        - Bug
-        - Improvement
-        - Feature
-        - Story
-    validations:
-      required: true
-
   - type: textarea
     id: description_text
     attributes:
       label: Descricao
-      placeholder: "Descreva resumidamente a demanda..."
+      description: "Objetivo da issue. Sem versao, sem label, sem type - isso vive nas sub-issues."
+      placeholder: "Ex.: Nova pagina de ranking"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/3-sub-issue.yml
+++ b/.github/ISSUE_TEMPLATE/3-sub-issue.yml
@@ -1,5 +1,5 @@
 name: "Sub-issue"
-description: "Sub-issue tecnica no formato [Label] [Type] - Descricao"
+description: "Sub-issue tecnica no formato [Label][Type] - Descricao"
 projects: ["CLT-Devops/3"]
 type: "Task"
 body:

--- a/.github/ISSUE_TEMPLATE/3-sub-issue.yml
+++ b/.github/ISSUE_TEMPLATE/3-sub-issue.yml
@@ -1,5 +1,5 @@
 name: "Sub-issue"
-description: "Sub-issue no formato [SI] - Objetivo"
+description: "Sub-issue tecnica no formato [Label] [Type] - Descricao"
 projects: ["CLT-Devops/3"]
 type: "Task"
 body:
@@ -27,6 +27,17 @@ body:
         - UI/UX
         - Layout
         - Component
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: Type obrigatorio da sub-issue.
+      options:
+        - Task
+        - Bug
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/4-atomic-fix.yml
+++ b/.github/ISSUE_TEMPLATE/4-atomic-fix.yml
@@ -1,0 +1,24 @@
+name: "Issue-atomica (Fix/Hotfix)"
+description: "Fix ou Hotfix sem escopo suficiente pra virar objetivo com sub-issues"
+projects: ["CLT-Devops/3"]
+type: "Bug"
+body:
+  - type: dropdown
+    id: categoria
+    attributes:
+      label: Categoria
+      description: Fix (bug comum) ou Hotfix (correcao urgente em producao).
+      options:
+        - Fix
+        - Hotfix
+    validations:
+      required: true
+
+  - type: textarea
+    id: description_text
+    attributes:
+      label: Descricao
+      description: "Problema e contexto. Sem label, sem type - issue-atomica resolve ela mesma."
+      placeholder: "Ex.: Corrigir timeout no handler completed"
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,13 @@
 ## Titulo do PR (padrao)
 <!--
-Use um destes formatos:
-Vx.y.z - [Label][Type] - Objetivo
-Vx.y.z - [SI] - Objetivo
+Use um destes formatos (sem versao no titulo - versionamento vai via tag no deploy):
+[Label][Type] - Objetivo         (PR de sub-issue normal)
+[Fix] - Objetivo                  (PR de issue-atomica Fix)
+[Hotfix] - Objetivo               (PR de issue-atomica Hotfix)
 -->
 
 ## Issue relacionada
-<!-- Obrigatorio. Ex.: Closes #123 -->
+<!-- Obrigatorio. Ex.: Closes #123. Para sub-issues acopladas no mesmo PR: Closes #2, #3, #4 -->
 Closes #
 
 ## Objetivo e contexto
@@ -32,7 +33,7 @@ Closes #
 - Plano de rollback:
 
 ## Checklist DoD (obrigatorio)
-- [ ] Escopo da issue foi entregue e validado
+- [ ] Escopo da sub-issue/issue-atomica foi entregue e validado
 - [ ] Testes (unit/integration/e2e) cobrindo o fluxo alterado
 - [ ] CI passou (lint, testes, checks de contrato quando aplicavel)
 - [ ] Logs estruturados atualizados (com correlation_id quando aplicavel)

--- a/.github/workflows/sync-issue-metadata.yml
+++ b/.github/workflows/sync-issue-metadata.yml
@@ -188,7 +188,7 @@ jobs:
 
             if (isSubIssue && selectedLabel && selectedTypeRaw && descriptionText) {
               const firstLine = descriptionText.split("\n")[0].trim();
-              desiredTitle = `[${selectedLabel}] [${selectedTypeRaw}] - ${firstLine}`;
+              desiredTitle = `[${selectedLabel}][${selectedTypeRaw}] - ${firstLine}`;
               compactBody = descriptionText;
             } else if (isAtomicFix && descriptionText) {
               const firstLine = descriptionText.split("\n")[0].trim();

--- a/.github/workflows/sync-issue-metadata.yml
+++ b/.github/workflows/sync-issue-metadata.yml
@@ -28,13 +28,10 @@ jobs:
             const TYPE_MAP = {
               task: "Task",
               bug: "Bug",
-              feature: "Feature",
-              improvement: "Feature",
-              story: "Feature",
             };
 
             const body = (issue.body || "").replace(/\r\n/g, "\n");
-            const isIssueForm = /^###\s*(Versao|Label|Type|Descricao|Descrição)\s*$/im.test(body);
+            const isIssueForm = /^###\s*(Label|Type|Categoria|Descricao|Descrição)\s*$/im.test(body);
             if (!isIssueForm) {
               core.info("Issue not created from configured issue form. Skipping.");
               return;
@@ -52,8 +49,7 @@ jobs:
               );
               const match = body.match(re);
               if (!match) return "";
-              const block = (match[2] || "").trim();
-              return block;
+              return (match[2] || "").trim();
             }
 
             function readField(fieldName) {
@@ -77,42 +73,6 @@ jobs:
                 .trim();
             }
 
-            function readCompactField(fieldName) {
-              const re = new RegExp(
-                `(^|\\n)${escapeRe(fieldName)}:\\s*(.+?)(?=\\n|$)`,
-                "i",
-              );
-              const match = body.match(re);
-              return match && match[2] ? match[2].trim() : "";
-            }
-
-            function parseStructuredTitle(value) {
-              const raw = (value || "").trim();
-              if (!raw) return null;
-
-              let match = raw.match(/^(.+?)\s-\s\[([^\]]+)\]\[([^\]]+)\]\s-\s(.+)$/);
-              if (match) {
-                return {
-                  version: match[1].trim(),
-                  label: match[2].trim(),
-                  type: match[3].trim(),
-                  objective: match[4].trim(),
-                };
-              }
-
-              match = raw.match(/^(.+?)\s-\s\[([^\]]+)\]\s\[([^\]]+)\]\s(.+)$/);
-              if (match) {
-                return {
-                  version: match[1].trim(),
-                  label: match[2].trim(),
-                  type: match[3].trim(),
-                  objective: match[4].trim(),
-                };
-              }
-
-              return null;
-            }
-
             function appendHtmlComments(text) {
               if (!text || htmlComments.length === 0) return text;
               const missing = htmlComments.filter((comment) => !text.includes(comment));
@@ -120,73 +80,26 @@ jobs:
               return `${text}\n${missing.join("\n")}`.trim();
             }
 
-            function extractVersionFromStructuredTitle(value) {
-              const raw = (value || "").trim();
-              if (!raw) return "";
-
-              let match = raw.match(/^(.+?)\s-\s\[[^\]]+\]\[[^\]]+\]\s-\s.+$/);
-              if (match && match[1]) return match[1].trim();
-
-              match = raw.match(/^(.+?)\s-\s\[[^\]]+\]\s\[[^\]]+\]\s.+$/);
-              if (match && match[1]) return match[1].trim();
-
-              return "";
-            }
-
-            async function getParentVersion(issueNumber) {
-              try {
-                const parentResp = await github.request(
-                  "GET /repos/{owner}/{repo}/issues/{issue_number}/parent",
-                  { owner, repo, issue_number: issueNumber },
-                );
-                const parentIssue = parentResp.data || {};
-                const titleVersion = extractVersionFromStructuredTitle(parentIssue.title || "");
-                if (titleVersion) return titleVersion;
-
-                const parentBody = (parentIssue.body || "").replace(/\r\n/g, "\n");
-                const bodyMatch = parentBody.match(/(^|\n)Versao:\s*(.+?)(?=\n|$)/i);
-                return bodyMatch && bodyMatch[2] ? bodyMatch[2].trim() : "";
-              } catch (err) {
-                if (err.status === 404) return "";
-                core.warning(`Could not load parent issue for #${issueNumber}: ${err.message}`);
-                return "";
-              }
-            }
-
-            function extractObjectiveFromTitle(value) {
-              const raw = (value || "").trim();
-              if (!raw) return "";
-
-              let match = raw.match(/^\[SI\]\s*-\s*(.+)$/i);
-              if (match && match[1]) return match[1].trim();
-
-              match = raw.match(/^.+?\s-\s\[[^\]]+\]\[[^\]]+\]\s-\s(.+)$/);
-              if (match && match[1]) return match[1].trim();
-
-              match = raw.match(/^.+?\s-\s\[[^\]]+\]\s\[[^\]]+\]\s(.+)$/);
-              if (match && match[1]) return match[1].trim();
-
-              return raw;
-            }
-
-            const titleData = parseStructuredTitle(issue.title);
-            const version = readField("Versao") || (titleData?.version || "") || readCompactField("Versao");
-            const selectedLabel = readField("Label") || (titleData?.label || "") || readCompactField("Label");
-            const selectedTypeRaw = readField("Type") || (titleData?.type || "") || readCompactField("Type");
-            const objective =
-              readField("Objetivo") ||
-              (titleData?.objective || "") ||
-              readCompactField("Objetivo") ||
-              extractObjectiveFromTitle(issue.title);
+            const selectedLabel = readField("Label");
+            const selectedTypeRaw = readField("Type");
+            const categoria = readField("Categoria");
             const descriptionText =
               readFieldMultiline("Descricao") || readFieldMultiline("Descrição");
             const selectedType = TYPE_MAP[(selectedTypeRaw || "").toLowerCase()] || "";
 
-            core.info(`Issue #${issue.number}`);
-            core.info(`Parsed: version='${version}', label='${selectedLabel}', type='${selectedTypeRaw}', objective='${objective}'`);
+            // Form detection:
+            //  - sub-issue: has Label AND Type
+            //  - atomic-fix: has Categoria (Fix/Hotfix)
+            //  - objetivo: only Descricao
+            const isSubIssue = !!selectedLabel && !!selectedTypeRaw;
+            const isAtomicFix = !!categoria;
+            const isObjetivo = !isSubIssue && !isAtomicFix;
 
-            // 1) Sync domain label from form.
-            if (selectedLabel && DOMAIN_LABELS.includes(selectedLabel)) {
+            core.info(`Issue #${issue.number}`);
+            core.info(`Parsed: label='${selectedLabel}', type='${selectedTypeRaw}', categoria='${categoria}', form=${isSubIssue ? "sub-issue" : isAtomicFix ? "atomic-fix" : "objetivo"}`);
+
+            // 1) Sync domain label (sub-issue only).
+            if (isSubIssue && DOMAIN_LABELS.includes(selectedLabel)) {
               const current = await github.paginate(
                 github.rest.issues.listLabelsOnIssue,
                 { owner, repo, issue_number: issue.number, per_page: 100 },
@@ -225,8 +138,8 @@ jobs:
               }
             }
 
-            // 2) Sync issue type (Task/Bug/Feature) from form.
-            if (selectedType) {
+            // 2) Sync issue type (sub-issue only; atomic-fix and objetivo come pre-set from the form-level `type:`).
+            if (isSubIssue && selectedType) {
               try {
                 const typeQuery = await github.graphql(
                   `query($owner: String!, $name: String!) {
@@ -272,34 +185,18 @@ jobs:
             // 3) Normalize title and compact body from form.
             let desiredTitle = "";
             let compactBody = "";
-            const isSubIssue =
-              issue.title.trim().startsWith("[SI] -") ||
-              (!version && !!selectedLabel && !!objective);
 
-            if (isSubIssue && objective) {
-              const parentVersion = await getParentVersion(issue.number);
-              desiredTitle = parentVersion
-                ? `${parentVersion} - [SI] - ${objective}`
-                : `[SI] - ${objective}`;
-              const bodyLines = [
-                `Label: ${selectedLabel || "-"}`,
-                "Type: Task",
-                `Objetivo: ${objective}`,
-              ];
-              compactBody = descriptionText
-                ? `${descriptionText}\n\n${bodyLines.join("\n")}`
-                : bodyLines.join("\n");
-            } else if (version && selectedLabel && selectedTypeRaw && objective) {
-              desiredTitle = `${version} - [${selectedLabel}][${selectedTypeRaw}] - ${objective}`;
-              const bodyLines = [
-                `Versao: ${version}`,
-                `Label: ${selectedLabel}`,
-                `Type: ${selectedTypeRaw}`,
-                `Objetivo: ${objective}`,
-              ];
-              compactBody = descriptionText
-                ? `${descriptionText}\n\n${bodyLines.join("\n")}`
-                : bodyLines.join("\n");
+            if (isSubIssue && selectedLabel && selectedTypeRaw && descriptionText) {
+              const firstLine = descriptionText.split("\n")[0].trim();
+              desiredTitle = `[${selectedLabel}] [${selectedTypeRaw}] - ${firstLine}`;
+              compactBody = descriptionText;
+            } else if (isAtomicFix && descriptionText) {
+              const firstLine = descriptionText.split("\n")[0].trim();
+              desiredTitle = `[${categoria}] - ${firstLine}`;
+              compactBody = descriptionText;
+            } else if (isObjetivo && descriptionText) {
+              // Objetivo: do not rewrite title (user's title stays). Compact body only.
+              compactBody = descriptionText;
             }
 
             compactBody = appendHtmlComments(compactBody);


### PR DESCRIPTION
## Issue relacionada
Closes CLT-Devops/Chinalink-GitHubOps#2
Closes CLT-Devops/Chinalink-GitHubOps#3
Closes CLT-Devops/Chinalink-GitHubOps#4
Closes CLT-Devops/Chinalink-GitHubOps#5
Closes CLT-Devops/Chinalink-GitHubOps#6
Closes CLT-Devops/Chinalink-GitHubOps#7
Refs CLT-Devops/Chinalink-GitHubOps#1

As 6 sub-issues sao tecnicamente acopladas (templates + parser): nao da pra shippar um template novo sem parser compativel, nem vice-versa. Por isso 1 PR unico.

## Objetivo e contexto
Aplicar a convencao v2 (milestone = versao, issue-objetivo = escopo puro, sub-issue = trabalho tecnico, tag-por-deploy) nos artefatos compartilhados da org em `CLT-Devops/.github`.

## O que mudou
- `1-geral.yml` e `2-web.yml`: removido Versao/Label/Type (issue-objetivo so tem Descricao)
- `3-sub-issue.yml`: adicionado dropdown Type (Task|Bug)
- `4-atomic-fix.yml` (novo): dropdown Categoria (Fix|Hotfix) + Descricao, issue type pre-set a Bug
- `pull_request_template.md`: removidas refs a `Vx.y.z` no titulo; formatos validos sao `[Label][Type] - Obj` / `[Fix] - Obj` / `[Hotfix] - Obj`
- `sync-issue-metadata.yml`: parser detecta form por campos presentes:
  - sub-issue (Label + Type) -> titulo `[Label] [Type] - Descricao`, sync label + issue type
  - atomic-fix (Categoria) -> titulo `[Fix|Hotfix] - Descricao`
  - objetivo (so Descricao) -> titulo do usuario mantido; so compacta body
  Toda logica de `Versao`, `[SI]`, parent lookup, etc, foi removida.

## Como validar
1. Abrir issue-objetivo via `1-geral` -> body compactado, titulo preservado, sem label/type forcados
2. Abrir sub-issue via `3-sub-issue` com Label + Type -> titulo vira `[Label] [Type] - Descricao`, domain label aplicada, issue type setado
3. Abrir issue-atomica via `4-atomic-fix` com Fix -> titulo vira `[Fix] - Descricao`
4. Repetir (3) com Hotfix
5. Conferir que nenhum dos 4 fluxos tenta inferir versao do titulo

## Observabilidade e alertas
- correlation_id nos logs impactados: n/a (workflow de infra org)
- eventos/telemetria alterados: nenhum
- alerta Slack criado/ajustado: nao aplicavel

## Risco e rollback
- Risco principal: issues antigas com body no formato V1.0.0 nao serao reprocessadas (parser so roda no evento de criacao/edicao). Issues novas pegam o formato novo automaticamente.
- Plano de rollback: revert do merge commit em .github; parser antigo volta a funcionar com os forms antigos (que ainda existem no historico git).

## Checklist DoD (obrigatorio)
- [x] Escopo da sub-issue/issue-atomica foi entregue e validado
- [x] Testes (unit/integration/e2e) cobrindo o fluxo alterado - validacao manual pos-merge via issue de teste
- [x] CI passou (lint, testes, checks de contrato quando aplicavel)
- [x] Logs estruturados atualizados (com correlation_id quando aplicavel) - n/a
- [x] Alertas Slack revisados/testados (quando aplicavel) - n/a
- [x] Nao ha segredo/token hardcoded
- [x] Sem breaking change nao documentada
- [x] Documentacao atualizada (se aplicavel) - CLAUDE.md global ja reflete a convencao v2

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>